### PR TITLE
Fixing Content Order Issues

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -105,7 +105,7 @@ class IndexPage extends React.Component {
           </section>
 
           <section className="row section align-items-center">
-            <div className="col-lg-6 d-flex align-items-center justify-content-center">
+            <div className="col-lg-6 d-flex align-items-center justify-content-center order-2 order-lg-1">
               <div className="embed-responsive-16by9 img-frame">
                 <img
                   src="https://voyager.postman.com/illustration/super-admin-postman-illustration.svg"
@@ -115,7 +115,7 @@ class IndexPage extends React.Component {
                 />
               </div>
             </div>
-            <div className="col-lg-6 order-first">
+            <div className="order-1 order-lg-2 col-lg-6">
               <br />
               <h2>Generate Code, Mocks, Documentation, API definitions, and many more</h2>
               <p>Collections are both human and machine readable, and have a suite of tools built around them by Postman and it’s community that let’s you generate client and server-side SDKs, documentation, mocks, convert to and from other API specifications and a lot more.</p>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -115,7 +115,7 @@ class IndexPage extends React.Component {
                 />
               </div>
             </div>
-            <div className="col-lg-6">
+            <div className="col-lg-6 order-first">
               <br />
               <h2>Generate Code, Mocks, Documentation, API definitions, and many more</h2>
               <p>Collections are both human and machine readable, and have a suite of tools built around them by Postman and it’s community that let’s you generate client and server-side SDKs, documentation, mocks, convert to and from other API specifications and a lot more.</p>


### PR DESCRIPTION
## Fixing Content Order Issues
This section appears in the order shown in the diagram below on desktop, which is completely fine based on the page layout.

![image](https://user-images.githubusercontent.com/57637620/222243381-afe84276-4c9d-4fe9-945b-8d39f94e428f.png)

On mobile screens, the text comes after the image which distorts the content layouts.
![image](https://user-images.githubusercontent.com/57637620/222244288-cd22bec4-6b7a-49e5-93d7-db8964b15baf.png)

### Suggested fix
To fix this issue and ensure it remains responsive, I have done the following;
- Added `order-2 order-lg-1` to the image. This will ensure the image stays as it is when viewed on desktop/large screens and comes second on mobile screens 
- Added `.order-1 .order-lg-2` to the text. This will ensure the text stays as it is when viewed on desktop/large screens and comes first on mobile screens to match the existing layout.



