### PR TITLE
[MARKENG-2419][c] Update LC:collection-format-docs to gtag UA-43979731-4

### DIFF
--- a/bff.js
+++ b/bff.js
@@ -114,6 +114,8 @@ setTimeout(function(){
           function gtag(){dataLayer.push(arguments);}
           window.gtag = gtag;
           gtag('js', new Date());
+          gtag('config', 'UA-43979731-4');
+          window.pmt('log', ['gtag: UA-43979731-4']);
           window.pmt('ga', ['${UACode}', sitename]);
           window.pmt('log', ['initialized GA: ' + sitename + ' (' + '${UACode}' + ')']);
           window._iaq = window._iaq || {};


### PR DESCRIPTION
### What are the changes?
 Branched from `develop`, this uses Google’s suggested syntax to tag “UA-43979731-4”.
 
### Why make these changes? 
   The updates the web app’s to GA code for GA4
      
<img width="1259" alt="image" src="https://user-images.githubusercontent.com/56083362/234989871-edd886a1-269a-48d6-bd10-f1d809afa6d2.png">
