### PR TITLE
Fix url page title

### DIFF
--- a/src/pages/reference/url.md
+++ b/src/pages/reference/url.md
@@ -1,7 +1,7 @@
 ---
-title: "Certificate"
+title: "URL"
 order: 1
-page_id: "certificate"
+page_id: "url"
 warning: false
 updated: 2022-11-15
 contextual_links:


### PR DESCRIPTION
The current title of the URL page is incorrectly set to `Certificate`.

Current:

![image](https://github.com/user-attachments/assets/df810142-3294-4576-956b-2ec82d6aa8fc)

---

Fix:

![image](https://github.com/user-attachments/assets/73f62f60-f988-4734-8c5d-5db4690eab43)
